### PR TITLE
Add customization options for DebugLog

### DIFF
--- a/ApDebugLog.cs
+++ b/ApDebugLog.cs
@@ -19,16 +19,21 @@ public class ApDebugLog : MonoBehaviour
     public static ApDebugLog Instance { get; private set; } = null!;
 
     // public DisplayMode displayMode = DisplayMode.Always;
+
+    // This block of variables will be overwritten using values from the settings menu, these values are just fallbacks in case this fails for some reason.
+    // If you're wanting to change default values, change them in the HasteSetting instead.
     public float yBaseOffset = 150f;
     public float xBaseOffset = -650f;
     public int fontSize = 16;
     public int lineSpacing = 20;
+    public bool messagesGoDown = true;
+    // --------------------------------
+
     public AlignmentMode alignmentMode = AlignmentMode.Left;
     public ColorizedMode colorizedMode = ColorizedMode.Colorized;
     public FontMode fontMode = FontMode.GameFont;
     public OutlineMode outlineMode = OutlineMode.Outline;
     public float _duration = 7f;
-    public bool messagesGoDown = true;
     private TMP_FontAsset _fontAsset = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().FirstOrDefault(font => font.name == "AkzidenzGroteskPro-Bold SDF");
 
     private Canvas? _canvas;

--- a/ApDebugLog.cs
+++ b/ApDebugLog.cs
@@ -28,6 +28,7 @@ public class ApDebugLog : MonoBehaviour
     public FontMode fontMode = FontMode.GameFont;
     public OutlineMode outlineMode = OutlineMode.Outline;
     public float _duration = 7f;
+    public bool messagesGoDown = true;
     private TMP_FontAsset _fontAsset = Resources.FindObjectsOfTypeAll<TMP_FontAsset>().FirstOrDefault(font => font.name == "AkzidenzGroteskPro-Bold SDF");
 
     private Canvas? _canvas;
@@ -217,7 +218,7 @@ public class ApDebugLog : MonoBehaviour
             {
                 RectTransform activeRect = activeMessages[i].MessageObject.GetComponent<RectTransform>();
                 activeRect.anchoredPosition = new Vector2(xBaseOffset, currentYOffset);
-                currentYOffset -= activeMessages[i].Height + lineSpacing;
+                currentYOffset += (activeMessages[i].Height + lineSpacing) * (messagesGoDown ? -1 : 1);
             }
         }
     }

--- a/Program.cs
+++ b/Program.cs
@@ -546,6 +546,62 @@ public class ApLogFilter : EnumSetting<APFilterMode>, IExposedSetting
 }
 
 [HasteSetting]
+public class ApLogXOffset : IntSetting, IExposedSetting
+{
+    public override void ApplyValue() => ApDebugLog.Instance.xBaseOffset = Value;
+    protected override int GetDefaultValue() => -650;
+    public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client X Offset");
+    public string GetCategory() => "AP";
+}
+
+[HasteSetting]
+public class ApLogYOffset : IntSetting, IExposedSetting
+{
+    public override void ApplyValue() => ApDebugLog.Instance.yBaseOffset = Value;
+    protected override int GetDefaultValue() => 150;
+    public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client Y Offset");
+    public string GetCategory() => "AP";
+}
+
+[HasteSetting]
+public class ApLogFontSize : IntSetting, IExposedSetting
+{
+    public override void ApplyValue()
+    {
+        ApDebugLog.Instance.fontSize = Value;
+    }
+    protected override int GetDefaultValue() => 16;
+    public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client Font Size");
+    public string GetCategory() => "AP";
+}
+
+[HasteSetting]
+public class ApLogLineSpacing : IntSetting, IExposedSetting
+{
+    public override void ApplyValue() => ApDebugLog.Instance.lineSpacing = Value;
+    protected override int GetDefaultValue() => 20;
+    public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client Line Spacing");
+    public string GetCategory() => "AP";
+}
+
+[HasteSetting]
+public class ApLogTestMessage : ButtonSetting, IExposedSetting
+{
+    public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client Example Message");
+    public string GetCategory() => "AP";
+
+    public override void OnClicked(ISettingHandler settingHandler)
+    {
+        ApDebugLog.Instance.DisplayMessage("This is a test message that is really long so that way you can make sure the text appears on screen correctly.", isDebug: false);
+    }
+
+    public override string GetButtonText()
+    {
+        return "Show Example Message";
+    }
+}
+
+[HasteSetting]
 public class ApServerNameSetting : StringSetting, IExposedSetting
 {
     public override void ApplyValue() => UnityMainThreadDispatcher.Instance().log($"New AP hostname {Value}");

--- a/Program.cs
+++ b/Program.cs
@@ -585,6 +585,17 @@ public class ApLogLineSpacing : IntSetting, IExposedSetting
 }
 
 [HasteSetting]
+public class ApLogDirection : BoolSetting, IExposedSetting
+{
+    public override LocalizedString OffString => new UnlocalizedString("Messages go up");
+    public override LocalizedString OnString => new UnlocalizedString("Messages go down");
+    public override void ApplyValue() => ApDebugLog.Instance.messagesGoDown = Value;
+    protected override bool GetDefaultValue() => true;
+    public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client Message Direction");
+    public string GetCategory() => "AP";
+}
+
+[HasteSetting]
 public class ApLogTestMessage : ButtonSetting, IExposedSetting
 {
     public LocalizedString GetDisplayName() => new UnlocalizedString("AP Text Client Example Message");


### PR DESCRIPTION
Adds the ability to customize both the position and message direction of the DebugLog, so it can be positioned by the user on any part of the screen.

Made as a workaround for #2