### PR TITLE
shop items shuffled into the AP pool

### DIFF
--- a/APConnection.cs
+++ b/APConnection.cs
@@ -473,6 +473,17 @@ public class Connection(string hostname, int port)
         {
             UnityMainThreadDispatcher.Instance().log($"AP found Item Unlocks in slot data with value: {ItemUnlocks}");
             FactSystem.SetFact(new Fact("Item Unlocks"), Convert.ToSingle(ItemUnlocks));
+                if (Convert.ToSingle(ItemUnlocks) == 1)
+                {
+                    if(FactSystem.GetFact(new Fact("APFirstLoad")) == 0f)
+                    {
+                    // lock all items once
+                        ItemDatabase.LockAll();
+                    }
+                    // the game resets the default unlocked items list on every load
+                    ItemDatabase.instance.defaultUnlockedItemsSet.Clear();
+                    ItemDatabase.instance.defaultUnlockedItems.Clear();
+                }
         }
         else
         {

--- a/APConnection.cs
+++ b/APConnection.cs
@@ -456,6 +456,7 @@ public class Connection(string hostname, int port)
         if (loginSuccess.SlotData.TryGetValue("Unlock All Items", out object UnlockAllItems))
         {
             UnityMainThreadDispatcher.Instance().log($"AP found UnlockAllItems in slot data with value: {UnlockAllItems}");
+            FactSystem.SetFact(new Fact("Unlock All Items"), Convert.ToSingle(UnlockAllItems));
             if (FactSystem.GetFact(new Fact("APFirstLoad")) == 0f && Convert.ToSingle(UnlockAllItems) == 1)
             {
                 //only unlock once
@@ -465,6 +466,18 @@ public class Connection(string hostname, int port)
         else
         {
             UnityMainThreadDispatcher.Instance().logError("AP Failed to get UnlockAllItems from slot data:" + loginSuccess.SlotData.toJson());
+            FactSystem.SetFact(new Fact("Unlock All Items"), 0f);
+        }
+
+        if (loginSuccess.SlotData.TryGetValue("Item Unlocks", out object ItemUnlocks))
+        {
+            UnityMainThreadDispatcher.Instance().log($"AP found Item Unlocks in slot data with value: {ItemUnlocks}");
+            FactSystem.SetFact(new Fact("Item Unlocks"), Convert.ToSingle(ItemUnlocks));
+        }
+        else
+        {
+            UnityMainThreadDispatcher.Instance().logError("AP Failed to get Item Unlocks from slot data:" + loginSuccess.SlotData.toJson());
+            FactSystem.SetFact(new Fact("Item Unlocks"), 0f);
         }
 
 

--- a/HasteAP.cs
+++ b/HasteAP.cs
@@ -768,19 +768,29 @@ public partial class HasteAP
                     self.Unset(i);
                 }
 
+                var apShopItem = ItemDatabase.instance.items.FirstOrDefault(x => x.itemName == "ArchipelagoShopItem");
+                bool itemUnlocksModeEnabled = FactSystem.GetFact(new Fact("Item Unlocks")) > 0f;
+                List<ItemInstance> acceptableItems = new List<ItemInstance>();
+                // The only acceptable items should be the ones that are AP-unlocked if item unlocks mode is on, otherwise all items are acceptable
+                if (itemUnlocksModeEnabled)
+                {              
+                    // Item Unlocks ON: Only show AP-unlocked items
+                    UnityMainThreadDispatcher.Instance().log($"AP Shop Sanity: Checking {ItemDatabase.instance.items.Count} items in database");
+
+                    acceptableItems = ItemDatabase.instance.items.Where(item => !Integration.Integration.IsItemLocked(GetItemName(item.itemName))).ToList();
+                }
+
+                int inX = (int)FactSystem.GetFact(new Fact("APShopsanitySeperateRate"));
                 for (int j = 0; j < 3; j++)
                 {
                     ItemInstance? itemToAddToShop = null;
-                    System.Random random = new System.Random();
                     //TODO: determine if there are no AP items left in that region, then make it spawn a normal item instead
                     // unless the inX is 100, then just let them keep getting useless items I guess (maybe another dummy item)
-                    int inX = (int)FactSystem.GetFact(new Fact("APShopsanitySeperateRate"));
-                    if (random.Next(1, 100) <= inX)
+                    if (currentLevelRandomInstance.Next(1, 100) <= inX)
                     {
-                        var ItemsThatShouldBeAPShop = ItemDatabase.instance.items.Where(x => x.itemName == "ArchipelagoShopItem").ToList();
-                        if (ItemsThatShouldBeAPShop.Count > 0)
+                        if (apShopItem != null)
                         {
-                            itemToAddToShop = ItemDatabase.instance.items.Where(x => x.itemName == "ArchipelagoShopItem").ToList()[0];
+                            itemToAddToShop = apShopItem;
                         }
                         else
                         {
@@ -789,7 +799,31 @@ public partial class HasteAP
                     }
                     else
                     {
-                        itemToAddToShop = self.testItem ? self.testItem : ItemDatabase.GetRandomItem(localPlayer, currentLevelRandomInstance, GetRandomItemFlags.Major, TagInteraction.None, null, excludedList, RunHandler.GetShopItemRarityModifier());
+                        if (acceptableItems.Count > 0 || !itemUnlocksModeEnabled)
+                        {
+                            if(itemUnlocksModeEnabled)
+                            {
+                                itemToAddToShop = acceptableItems[currentLevelRandomInstance.Next(acceptableItems.Count)];
+                            }
+                            else 
+                            {
+                                // pre-item-unlocks logic, should be the same as the original shopsanity item generation
+                                itemToAddToShop = self.testItem ? self.testItem : ItemDatabase.GetRandomItem(localPlayer, currentLevelRandomInstance, GetRandomItemFlags.Major, TagInteraction.None, null, excludedList, RunHandler.GetShopItemRarityModifier());
+                            }
+
+                            for(int p = 0; p < self.itemInstances.Count; p++) {
+                                if (itemToAddToShop != null && self.itemInstances[p] != null && self.itemInstances[p].itemName == itemToAddToShop.itemName)
+                                {
+                                    // if the item is already in the shop, then replace it with an AP shop item instead to avoid duplicates
+                                    // dupes happens a lot early game when item unlocks mode is on, so this added logic is here to hopefully prevent that
+                                    if (apShopItem != null)
+                                    {
+                                        itemToAddToShop = apShopItem;
+                                        UnityMainThreadDispatcher.Instance().log($"No replacement found, using AP shop item for {itemToAddToShop.itemName}");
+                                    }
+                                }
+                            }
+                        }
                     }
                     if (itemToAddToShop != null)
                     {
@@ -1124,6 +1158,7 @@ public partial class HasteAP
 
     private static void StaticMetaProgressionRefreshUIHook(On.Landfall.Haste.MetaProgressionRowUI.orig_RefreshUI orig, MetaProgressionRowUI self)
     {
+        // TODO: With ItemUnlocks mode, the all items list in the hub is inaccurate and needs to be updated to reflect the actual unlocked items through AP
         orig(self);
         if (FactSystem.GetFact(new Fact("APCaptainsRewards")) == 1f)
         {

--- a/HasteAP.cs
+++ b/HasteAP.cs
@@ -2,6 +2,7 @@ using APConnection;
 using Archipelago.MultiClient.Net.BounceFeatures.DeathLink;
 using Landfall.Haste;
 using Landfall.Modding;
+using System.ComponentModel.Composition;
 using System.Reflection;
 using System.Text;
 using TMPro;
@@ -222,7 +223,7 @@ public partial class HasteAP
         On.PlayerCharacter.RestartPlayer_Launch_Transform_float += StaticSetSpeed;
         On.PlayerCharacter.RestartPlayer_Still_Transform += StaticSetSpeed;
         On.PlayerMovement.Land += StaticLandingHook;
-
+        On.RunHandler.TransitionOnLevelCompleted += StaticTransitionOnLevelCompleted;
 
         UnityMainThreadDispatcher.Instance().log("AP Hooks Complete");
 
@@ -268,6 +269,7 @@ public partial class HasteAP
         On.PlayerCharacter.RestartPlayer_Launch_Transform_float -= StaticSetSpeed;
         On.PlayerCharacter.RestartPlayer_Still_Transform -= StaticSetSpeed;
         On.PlayerMovement.Land -= StaticLandingHook;
+        On.RunHandler.TransitionOnLevelCompleted -= StaticTransitionOnLevelCompleted;
         On.Landfall.Haste.MetaProgressionRowUI.AddClicked -= StaticMetaProgressionRowAddClickedHook;
         On.Landfall.Haste.MetaProgressionRowUI.RefreshUI -= StaticMetaProgressionRefreshUIHook;
         On.Landfall.Haste.MetaProgression.GetCurrentLevel -= StaticMetaProgressionGetCurrentLevelHook;
@@ -777,16 +779,27 @@ public partial class HasteAP
                     // Item Unlocks ON: Only show AP-unlocked items
                     UnityMainThreadDispatcher.Instance().log($"AP Shop Sanity: Checking {ItemDatabase.instance.items.Count} items in database");
 
-                    acceptableItems = ItemDatabase.instance.items.Where(item => !Integration.Integration.IsItemLocked(GetItemName(item.itemName))).ToList();
+                    acceptableItems = ItemDatabase.instance.items.Where(item => Integration.Integration.IsItemUnlocked(GetItemName(item.itemName))).ToList();
                 }
 
+                bool anyArchipelagoItemsLeft = false;
+                var currentShard = RunHandler.RunData.shardID + 1;
                 int inX = (int)FactSystem.GetFact(new Fact("APShopsanitySeperateRate"));
                 for (int j = 0; j < 3; j++)
                 {
                     ItemInstance? itemToAddToShop = null;
                     //TODO: determine if there are no AP items left in that region, then make it spawn a normal item instead
                     // unless the inX is 100, then just let them keep getting useless items I guess (maybe another dummy item)
-                    if (currentLevelRandomInstance.Next(1, 100) <= inX)
+                    if (FactSystem.GetFact(new Fact("APShopsanity")) == 1f)
+                    {
+                        anyArchipelagoItemsLeft = FactSystem.GetFact(new Fact("APShopsanityShard" + currentShard)) < FactSystem.GetFact(new Fact("APShopsanityQuantity"));
+                    }
+                    else if (FactSystem.GetFact(new Fact("APShopsanity")) == 2f)
+                    {
+                        anyArchipelagoItemsLeft = FactSystem.GetFact(new Fact("APShopsanityGlobal")) < FactSystem.GetFact(new Fact("APShopsanityQuantity"));
+                    }
+
+                    if (currentLevelRandomInstance.Next(1, 100) <= inX && anyArchipelagoItemsLeft)
                     {
                         if (apShopItem != null)
                         {
@@ -831,6 +844,12 @@ public partial class HasteAP
                         if (itemToAddToShop.itemName != "ArchipelagoShopItem") excludedList.Add(itemToAddToShop);
                         self.itemInstances.Add(itemToAddToShop);
                     }
+                    else
+                    {
+                        itemToAddToShop = apShopItem;
+                        self.itemInstances.Add(itemToAddToShop);
+                        UnityMainThreadDispatcher.Instance().log($"No item found, using AP shop item for slot {j}");
+                    }
                 }
             }
             catch (Exception e)
@@ -847,6 +866,17 @@ public partial class HasteAP
         }
     }
 
+    public static void StaticTransitionOnLevelCompleted(On.RunHandler.orig_TransitionOnLevelCompleted orig)
+    {
+        orig();
+        if (RunHandler.RunData.currentNode.type == LevelSelectionNode.NodeType.Challenge && RunHandler.InRun 
+        && RunHandler.RunData.currentNodeStatus == NGOPlayer.PlayerNodeStatus.PostLevelScreen && APItemUnlockCount() < 3)
+        {
+            RunHandler.RunData.currentNodeStatus = NGOPlayer.PlayerNodeStatus.PostLevelScreenComplete;
+            UnityMainThreadDispatcher.Instance().logError($"Set shard status to PostLevelScreenComplete");
+        }
+
+    }
 
     /// <summary>
     /// Hook into when a player buys and item. Used to give item locations
@@ -1363,6 +1393,113 @@ public partial class HasteAP
         if (connection.GetItemCount("Persistent Epic Support Item") is var peu and > 0) FactSystem.SetFact(new Fact("APEpicSupportItems"), peu);
         if (connection.GetItemCount("Persistent Epic Health Item") is var peh and > 0) FactSystem.SetFact(new Fact("APEpicHealthItems"), peh);
         if (connection.GetItemCount("Persistent Legendary Item") is var pl and > 0) FactSystem.SetFact(new Fact("APLegendaryItems"), pl);
+
+        // BOOST ITEMS
+        if (connection.GetItemCount("Blood Engine") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BloodEngine"), 1);
+        if (connection.GetItemCount("Boost Remote") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BoostRemote"), 1);
+        if (connection.GetItemCount("BOOSTR POG") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BOOSTRPOG"), 1);
+        if (connection.GetItemCount("Bootleg Pattern") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BootlegPattern"), 1);
+        if (connection.GetItemCount("Charge Boots") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ChargeBoots"), 1);
+        if (connection.GetItemCount("Cherry on Top") > 0) FactSystem.SetFact(new Fact("APItemUnlock_CherryOnTop"), 1);
+        if (connection.GetItemCount("Energy Lasso") > 0) FactSystem.SetFact(new Fact("APItemUnlock_EnergyLasso"), 1);
+        if (connection.GetItemCount("Experimental Autopilot") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ExperimentalAutopilot"), 1);
+        if (connection.GetItemCount("Experimental Thrusters") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ExperimentalThrusters"), 1);
+        if (connection.GetItemCount("Fragile Confidence") > 0) FactSystem.SetFact(new Fact("APItemUnlock_FragileConfidence"), 1);
+        if (connection.GetItemCount("Golden Necklace") > 0) FactSystem.SetFact(new Fact("APItemUnlock_GoldenNecklace"), 1);
+        if (connection.GetItemCount("Big Spark Magnet") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BigSparkMagnet"), 1);
+        if (connection.GetItemCount("Heir's Determination") > 0) FactSystem.SetFact(new Fact("APItemUnlock_HeirsDetermination"), 1);
+        if (connection.GetItemCount("Mysterious Spring") > 0) FactSystem.SetFact(new Fact("APItemUnlock_MysteriousSpring"), 1);
+        if (connection.GetItemCount("Painful Coil") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PainfulCoil"), 1);
+        if (connection.GetItemCount("Pathfinder") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Pathfinder"), 1);
+        if (connection.GetItemCount("Perpetual Motion Machine") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PerpetualMotionMachine"), 1);
+        if (connection.GetItemCount("Personal Gravity Enhancer") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PersonalGravityEnhancer"), 1);
+        if (connection.GetItemCount("Recyclable Rocket") > 0) FactSystem.SetFact(new Fact("APItemUnlock_RecyclableRocket"), 1);
+        if (connection.GetItemCount("Ring Materializer") > 0) FactSystem.SetFact(new Fact("APItemUnlock_RingMaterializer"), 1);
+        if (connection.GetItemCount("Risk and Reward") > 0) FactSystem.SetFact(new Fact("APItemUnlock_RiskandReward"), 1);
+        if (connection.GetItemCount("Emergency Shoes") > 0) FactSystem.SetFact(new Fact("APItemUnlock_EmergencyShoes"), 1);
+        if (connection.GetItemCount("Greed Machine") > 0) FactSystem.SetFact(new Fact("APItemUnlock_GreedMachine"), 1);
+        if (connection.GetItemCount("Rocket Boots") > 0) FactSystem.SetFact(new Fact("APItemUnlock_RocketBoots"), 1);
+        if (connection.GetItemCount("Secret Technique Instructions") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SecretTechniqueInstructions"), 1);
+        if (connection.GetItemCount("Shiny Anchor Pin") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ShinyAnchorPin"), 1);
+        if (connection.GetItemCount("Shortcut") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Shortcut"), 1);
+        if (connection.GetItemCount("Spark Dasher") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SparkDasher"), 1);
+        if (connection.GetItemCount("Spark Plug") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SparkPlug"), 1);
+        if (connection.GetItemCount("Spark Powered Propeller") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SparkPoweredPropeller"), 1);
+        if (connection.GetItemCount("Standard Redirector") > 0) FactSystem.SetFact(new Fact("APItemUnlock_StandardRedirector"), 1);
+        if (connection.GetItemCount("Time Dilation Thing") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TimeDilationThing"), 1);
+        if (connection.GetItemCount("Timeline Attractor") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TimelineAttractor"), 1);
+        if (connection.GetItemCount("Timeline Shifter") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TimelineShifter"), 1);
+        if (connection.GetItemCount("Transition Slingshot") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TransitionSlingshot"), 1);
+        if (connection.GetItemCount("Vitamins") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Vitamins"), 1);
+        if (connection.GetItemCount("Well Earned Confidence") > 0) FactSystem.SetFact(new Fact("APItemUnlock_WellEarnedConfidence"), 1);
+        if (connection.GetItemCount("Wingspan") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Wingspan"), 1);
+
+
+        // SUPPORT ITEMS
+        if (connection.GetItemCount("400-leaf Clover") > 0) FactSystem.SetFact(new Fact("APItemUnlock_400leafClover"), 1);
+        if (connection.GetItemCount("Adrenaline") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Adrenaline"), 1);
+        if (connection.GetItemCount("Atomic Timepiece") > 0) FactSystem.SetFact(new Fact("APItemUnlock_AtomicTimepiece"), 1);
+        if (connection.GetItemCount("Clown Shoes") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ClownShoes"), 1);
+        if (connection.GetItemCount("Dangerous Investment Scheme") > 0) FactSystem.SetFact(new Fact("APItemUnlock_DangerousInvestmentScheme"), 1);
+        if (connection.GetItemCount("Dynamo Treadmill") > 0) FactSystem.SetFact(new Fact("APItemUnlock_DynamoTreadmill"), 1);
+        if (connection.GetItemCount("Flashback") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Flashback"), 1);
+        if (connection.GetItemCount("General Relativity") > 0) FactSystem.SetFact(new Fact("APItemUnlock_GeneralRelativity"), 1);
+        if (connection.GetItemCount("Heart Shaped Mirror") > 0) FactSystem.SetFact(new Fact("APItemUnlock_HeartShapedMirror"), 1);
+        if (connection.GetItemCount("High Risk Investment") > 0) FactSystem.SetFact(new Fact("APItemUnlock_HighRiskInvestment"), 1);
+        if (connection.GetItemCount("Instant Compensation Machine") > 0) FactSystem.SetFact(new Fact("APItemUnlock_InstantCompensationMachine"), 1);
+        if (connection.GetItemCount("Interest") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Interest"), 1);
+        if (connection.GetItemCount("Jackpot") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Jackpot"), 1);
+        if (connection.GetItemCount("Karma") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Karma"), 1);
+        if (connection.GetItemCount("Momentum Recalibrator") > 0) FactSystem.SetFact(new Fact("APItemUnlock_MomentumRecalibrator"), 1);
+        if (connection.GetItemCount("N-Dimensional-leaf Clover") > 0) FactSystem.SetFact(new Fact("APItemUnlock_NDimensionalleafClover"), 1);
+        if (connection.GetItemCount("Overcomplicated Coin") > 0) FactSystem.SetFact(new Fact("APItemUnlock_OvercomplicatedCoin"), 1);
+        if (connection.GetItemCount("Overwound Pocketwatch") > 0) FactSystem.SetFact(new Fact("APItemUnlock_OverwoundPocketwatch"), 1);
+        if (connection.GetItemCount("Planar Reconfiguration") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PlanarReconfiguration"), 1);
+        if (connection.GetItemCount("Plutonium Coin") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PlutoniumCoin"), 1);
+        if (connection.GetItemCount("Portable Harvester") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PortableHarvester"), 1);
+        if (connection.GetItemCount("Shimmering Condenser") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ShimmeringCondenser"), 1);
+        if (connection.GetItemCount("Spark Furnace") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SparkFurnace"), 1);
+        if (connection.GetItemCount("Steady Investment") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SteadyInvestment"), 1);
+        if (connection.GetItemCount("Tight Schedule") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TightSchedule"), 1);
+        if (connection.GetItemCount("Timeline Recalibrator") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TimelineRecalibrator"), 1);
+        if (connection.GetItemCount("Void Charger") > 0) FactSystem.SetFact(new Fact("APItemUnlock_VoidCharger"), 1);
+        if (connection.GetItemCount("Void Compressor") > 0) FactSystem.SetFact(new Fact("APItemUnlock_VoidCompressor"), 1);
+
+
+        // HEALTH ITEMS
+        if (connection.GetItemCount("Aromatic Herbs") > 0) FactSystem.SetFact(new Fact("APItemUnlock_AromaticHerbs"), 1);
+        if (connection.GetItemCount("Big Pumpkin") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BigPumpkin"), 1);
+        if (connection.GetItemCount("Big Squash") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BigSquash"), 1);
+        if (connection.GetItemCount("Bitter Herbs") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BitterHerbs"), 1);
+        if (connection.GetItemCount("Brittle Breastplate") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BrittleBreastplate"), 1);
+        if (connection.GetItemCount("Delayed Emergency Device") > 0) FactSystem.SetFact(new Fact("APItemUnlock_DelayedEmergencyDevice"), 1);
+        if (connection.GetItemCount("Distance-Based Health Insurance") > 0) FactSystem.SetFact(new Fact("APItemUnlock_DistanceBasedHealthInsurance"), 1);
+        if (connection.GetItemCount("Energy Funnel") > 0) FactSystem.SetFact(new Fact("APItemUnlock_EnergyFunnel"), 1);
+        if (connection.GetItemCount("Extreme Herbs") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ExtremeHerbs"), 1);
+        if (connection.GetItemCount("Fragile Taco") > 0) FactSystem.SetFact(new Fact("APItemUnlock_FragileTaco"), 1);
+        if (connection.GetItemCount("Friendly Looking Star") > 0) FactSystem.SetFact(new Fact("APItemUnlock_FriendlyLookingStar"), 1);
+        if (connection.GetItemCount("Grunt's Helmet") > 0) FactSystem.SetFact(new Fact("APItemUnlock_GruntsHelmet"), 1);
+        if (connection.GetItemCount("Impact Activated Healing Drone") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ImpactActivatedHealingDrone"), 1);
+        if (connection.GetItemCount("Impulse Activated Stabilizer") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ImpulseActivatedStabilizer"), 1);
+        if (connection.GetItemCount("Intangibility") > 0) FactSystem.SetFact(new Fact("APItemUnlock_Intangibility"), 1);
+        if (connection.GetItemCount("Leadership Pipe") > 0) FactSystem.SetFact(new Fact("APItemUnlock_LeadershipPipe"), 1);
+        if (connection.GetItemCount("Low Grade Timeline Swapper") > 0) FactSystem.SetFact(new Fact("APItemUnlock_LowGradeTimelineSwapper"), 1);
+        if (connection.GetItemCount("Mortar and Pestle") > 0) FactSystem.SetFact(new Fact("APItemUnlock_MortarAndPestle"), 1);
+        if (connection.GetItemCount("Otherworldly Contact") > 0) FactSystem.SetFact(new Fact("APItemUnlock_OtherworldlyContact"), 1);
+        if (connection.GetItemCount("Overclocked Medical Drone") > 0) FactSystem.SetFact(new Fact("APItemUnlock_OverclockedMedicalDrone"), 1);
+        if (connection.GetItemCount("Performance Based Health Insurance") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PerformanceBasedHealthInsurance"), 1);
+        if (connection.GetItemCount("Personal Matter Stabilizer") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PersonalMatterStabilizer"), 1);
+        if (connection.GetItemCount("Pocket Snack") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PocketSnack"), 1);
+        if (connection.GetItemCount("Protective Medallion") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ProtectiveMedallion"), 1);
+        if (connection.GetItemCount("Pungent Herbs") > 0) FactSystem.SetFact(new Fact("APItemUnlock_PungentHerbs"), 1);
+        if (connection.GetItemCount("Quick Taco") > 0) FactSystem.SetFact(new Fact("APItemUnlock_QuickTaco"), 1);
+        if (connection.GetItemCount("Reheated Soup") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ReheatedSoup"), 1);
+        if (connection.GetItemCount("Replenishing Vial") > 0) FactSystem.SetFact(new Fact("APItemUnlock_ReplenishingVial"), 1);
+        if (connection.GetItemCount("Restorative Maneuver") > 0) FactSystem.SetFact(new Fact("APItemUnlock_RestorativeManeuver"), 1);
+        if (connection.GetItemCount("Velocity Powered Syringe") > 0) FactSystem.SetFact(new Fact("APItemUnlock_VelocityPoweredSyringe"), 1);
+        if (connection.GetItemCount("Steel Hat Lining") > 0) FactSystem.SetFact(new Fact("APItemUnlock_SteelHatLining"), 1);
+        if (connection.GetItemCount("Timeline Refactor") > 0) FactSystem.SetFact(new Fact("APItemUnlock_TimelineRefactor"), 1);
+        if (connection.GetItemCount("Blood Engine") > 0) FactSystem.SetFact(new Fact("APItemUnlock_BloodEngine"), 1);
         
         Player.localPlayer.ResetStats();
         SaveSystem.Save();

--- a/Intergration.cs
+++ b/Intergration.cs
@@ -18,6 +18,109 @@ namespace Integration
 
         public static APConnection.Connection? connection;
 
+        private static readonly HashSet<string> ItemUnlocks = new()
+        {
+            "Adrenaline",
+            "Aromatic Herbs",
+            "Atomic Timepiece",
+            "BOOSTR POG",
+            "Big Pumpkin",
+            "Big Spark Magnet",
+            "Big Squash",
+            "Bitter Herbs",
+            "Blood Engine",
+            "Boost Remote",
+            "Bootleg Pattern",
+            "Brittle Breastplate",
+            "Charge Boots",
+            "Cherry on Top",
+            "Clown Shoes",
+            "Dangerous Investment Scheme",
+            "Delayed Emergency Device",
+            "Distance-Based Health Insurance",
+            "Dynamo Treadmill",
+            "Emergency Shoes",
+            "Energy Funnel",
+            "Energy Lash",
+            "Experimental Autopilot",
+            "Experimental Thrusters",
+            "Extreme Herbs",
+            "Flashback",
+            "Fragile Confidence",
+            "Fragile Taco",
+            "Friendly Looking Star",
+            "General Relativity",
+            "Golden Necklace",
+            "Greed Machine",
+            "Growth Potential",
+            "Grunt's Helmet",
+            "Heart Shaped Mirror",
+            "Heir's Determination",
+            "High Risk Investment",
+            "Impact Activated Healing Drone",
+            "Impulse Actived Stabilizer",
+            "Instant Compensation Machine",
+            "Intangibility",
+            "Interest",
+            "Jackpot",
+            "Karma",
+            "Leadership Pipe",
+            "Low Grade Timeline Swapper",
+            "Momentum Recalibrator",
+            "Mortar and Pestle",
+            "Mysterious Spring",
+            "N-Dimensional-lead Clover",
+            "Otherworldly Contact",
+            "Overclocked Medical Drone",
+            "Overcomplicated Coin",
+            "Overwound Pocketwatch",
+            "Painful Coil",
+            "Pathfinder",
+            "Performance Based Health Insurance",
+            "Perpetual Motion Machine",
+            "Personal Gravity Enhancer",
+            "Personal Matter Stabilizer",
+            "Planar Reconfiguration",
+            "Plutonium Coin",
+            "Pocket Snack",
+            "Portable Harvester",
+            "Protective Medallion",
+            "Pungent Herbs",
+            "Quick Taco",
+            "Recyclable Rocket",
+            "Reheated Soup",
+            "Replenishing Vial",
+            "Restorative Maneuver",
+            "Ring Materializer",
+            "Risk and Reward",
+            "Rocket Boots",
+            "Secret Technique Instructions",
+            "Shimmering Condenser",
+            "Shiny Anchor Pin",
+            "Shortcut",
+            "Spark Dasher",
+            "Spark Furnace",
+            "Spark Plug",
+            "Spark Powered Propeller",
+            "Speedy Recovery",
+            "Standard Redirector",
+            "Steady Investment",
+            "Steel Hat Lining",
+            "Tight Schedule",
+            "Time Dilation Thing",
+            "Timeline Attractor",
+            "Timeline Recalibrator",
+            "Timeline Refactor",
+            "Timeline Shifter",
+            "Transition Slingshot",
+            "Velocity Powered Syringe",
+            "Vitamins",
+            "Void Charger",
+            "Void Compressor",
+            "Well Earned Confidence",
+            "Wingspan"
+        };
+
         public static void UpdateShardCount()
         {
             var _shardCount = connection!.GetItemCount("Progressive Shard");
@@ -45,274 +148,281 @@ namespace Integration
 
             try
             {
-
-                switch (itemName)
+                if (ItemUnlocks.Contains(itemName))
                 {
-                    case "A New Future":
-                        // wincon item, ignore
-                        break;
-                    case "Progressive Shard":
-                        UnityMainThreadDispatcher.Instance().log("AP Got a Shard!");
-                        ApDebugLog.Instance.DisplayMessage("Got Shard");
-                        // Increase the number of shards that the player can use
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Progressive Shard");
-                        UpdateShardCount();
-                        DecideForceReload();
-                        break;
-                    case "Shard Shop Filler Item":
-                        // 80% sure this item can't actually spawn but I'll keep it here anyway
-                        UnityMainThreadDispatcher.Instance().log("AP Got a filler item");
-                        ApDebugLog.Instance.DisplayMessage("Got Filler");
-                        break;
-                    case "Wraith's Hourglass":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Ability Slomo");
-                        ApDebugLog.Instance.DisplayMessage("Got Wraith's Hourglass");
-                        HasteAP.SecretAbilityUnlock(AbilityKind.Slomo);
-                        SaveSystem.Save();
-                        worthMentioning = true;
-                        break;
-                    case "Heir's Javelin":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Ability Grapple");
-                        ApDebugLog.Instance.DisplayMessage("Got Heir's Javelin");
-                        HasteAP.SecretAbilityUnlock(AbilityKind.Grapple);
-                        SaveSystem.Save();
-                        worthMentioning = true;
-                        break;
-                    case "Sage's Cowl":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Ability Fly");
-                        ApDebugLog.Instance.DisplayMessage("Got Sage's Cowl");
-                        HasteAP.SecretAbilityUnlock(AbilityKind.Fly);
-                        SaveSystem.Save();
-                        worthMentioning = true;
-                        break;
-                    case "Courier's Board":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Ability Boost");
-                        ApDebugLog.Instance.DisplayMessage("Got Courier's Board");
-                        HasteAP.SecretAbilityUnlock(AbilityKind.BoardBoost);
-                        SaveSystem.Save();
-                        worthMentioning = true;
-                        break;
-                    case "Wraith":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Wraith");
-                        ApDebugLog.Instance.DisplayMessage("Got Wraith in hub");
-                        FactSystem.SetFact(new Fact("APWraithInHub"), 1f);
-                        worthMentioning = true;
-                        DecideForceReload();
-                        break;
-                    case "Niada":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Niada");
-                        ApDebugLog.Instance.DisplayMessage("Got Niada in hub");
-                        FactSystem.SetFact(new Fact("APHeirInHub"), 1f);
-                        worthMentioning = true;
-                        DecideForceReload();
-                        break;
-                    case "Daro":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Daro");
-                        ApDebugLog.Instance.DisplayMessage("Got Daro in hub");
-                        FactSystem.SetFact(new Fact("APSageInHub"), 1f);
-                        worthMentioning = true;
-                        DecideForceReload();
-                        break;
-                    case "The Captain":
-                        UnityMainThreadDispatcher.Instance().log("AP Got The Captain");
-                        ApDebugLog.Instance.DisplayMessage("Got The Captain");
-                        FactSystem.SetFact(new Fact("APCaptainInHub"), 1f);
-                        worthMentioning = true;
-                        DecideForceReload();
-                        break;
-                    case "Fashion Weeboh":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Fashion Weeboh");
-                        ApDebugLog.Instance.DisplayMessage("Got Fashion Weeboh");
-                        FactSystem.SetFact(new Fact("APFashionInHub"), 1f);
-                        worthMentioning = true;
-                        DecideForceReload();
-                        break;
-                    case "Progressive Speed Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Progressive Speed Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Progressive Speed Upgrade");
-                        FactSystem.AddToFact(new Fact("APSpeedUpgradesCollected"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Progressive Speed Upgrade");
-                        break;
-                    case "Max Health Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Max Health Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Max Health Upgrade");
-                        FactSystem.AddToFact(new Fact("APUpgradeMaxHealth"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Max Health Upgrade");
-                        Player.localPlayer.ResetStats();
-                        break;
-                    case "Max Lives Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Extra Lives Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Extra Lives Upgrade");
-                        // extra lives upgrade on first get because its coded really weirdly
-                        if (FactSystem.GetFact(new Fact("APUpgradeMaxLives")) == 0f) FactSystem.AddToFact(new Fact("APUpgradeMaxLives"), 1f);
-                        FactSystem.AddToFact(new Fact("APUpgradeMaxLives"), 1f);
-                        worthMentioning = true;
-                        Player.localPlayer.ResetStats();
-                        break;
-                    case "Max Energy Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Max Energy Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Max Energy Upgrade");
-                        FactSystem.AddToFact(new Fact("APUpgradeMaxEnergy"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Max Energy Upgrade");
-                        Player.localPlayer.ResetStats();
-                        break;
-                    case "Sparks in Fragments Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Sparks in Fragments Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Sparks in Fragments Upgrade");
-                        FactSystem.AddToFact(new Fact("APUpgradeLevelSparks"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Sparks in Fragments Upgrade");
-                        Player.localPlayer.ResetStats();
-                        break;
-                    case "Item Rarity Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Item Rarity Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Item Rarity Upgrade");
-                        FactSystem.AddToFact(new Fact("APUpgradeItemRarity"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Item Rarity Upgrade");
-                        Player.localPlayer.ResetStats();
-                        break;
-                    case "Starting Sparks Upgrade":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Starting Sparks Upgrade");
-                        ApDebugLog.Instance.DisplayMessage("Got Starting Sparks Upgrade");
-                        FactSystem.AddToFact(new Fact("APUpgradeStartingSparks"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Starting Sparks Upgrade");
-                        Player.localPlayer.ResetStats();
-                        break;
-                    case "Persistent Common Speed Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Common Speed Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Common Speed Item");
-                        FactSystem.AddToFact(new Fact("APCommonSpeedItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Common Speed Item");
-                        ForcePermItem(Rarity.Common, APItemCategory.Speed);
-                        break;
-                    case "Persistent Common Support Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Common Support Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Common Support Item");
-                        FactSystem.AddToFact(new Fact("APCommonSupportItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Common Support Item");
-                        ForcePermItem(Rarity.Common, APItemCategory.Support);
-                        break;
-                    case "Persistent Common Health Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Common Health Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Common Health Item");
-                        FactSystem.AddToFact(new Fact("APCommonHealthItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Common Health Item");
-                        ForcePermItem(Rarity.Common, APItemCategory.Health);
-                        break;
-                    case "Persistent Rare Speed Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Rare Speed Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Rare Speed Item");
-                        FactSystem.AddToFact(new Fact("APRareSpeedItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Rare Speed Item");
-                        ForcePermItem(Rarity.Rare, APItemCategory.Speed);
-                        break;
-                    case "Persistent Rare Support Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Rare Support Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Rare Support Item");
-                        FactSystem.AddToFact(new Fact("APRareSupportItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Rare Support Item");
-                        ForcePermItem(Rarity.Rare, APItemCategory.Support);
-                        break;
-                    case "Persistent Rare Health Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Rare Health Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Rare Health Item");
-                        FactSystem.AddToFact(new Fact("APRareHealthItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Rare Health Item");
-                        ForcePermItem(Rarity.Rare, APItemCategory.Health);
-                        break;
-                    case "Persistent Epic Speed Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Epic Speed Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Epic Speed Item");
-                        FactSystem.AddToFact(new Fact("APEpicSpeedItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Epic Speed Item");
-                        ForcePermItem(Rarity.Epic, APItemCategory.Speed);
-                        break;
-                    case "Persistent Epic Support Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Epic Support Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Epic Support Item");
-                        FactSystem.AddToFact(new Fact("APEpicSupportItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Epic Support Item");
-                        ForcePermItem(Rarity.Epic, APItemCategory.Support);
-                        break;
-                    case "Persistent Epic Health Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Epic Health Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Epic Health Item");
-                        FactSystem.AddToFact(new Fact("APEpicHealthItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Epic Health Item");
-                        ForcePermItem(Rarity.Epic, APItemCategory.Health);
-                        break;
-                    case "Persistent Legendary Item":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Persistent Legendary Item");
-                        ApDebugLog.Instance.DisplayMessage("Got Persistent Legendary Item");
-                        FactSystem.AddToFact(new Fact("APLegendaryItems"), 1f);
-                        worthMentioning = true;
-                        quantity = connection!.GetItemCount("Persistent Legendary Item");
-                        ForcePermItem(Rarity.Legendary, APItemCategory.Legendary);
-                        break;
-                    case "Anti-Spark 10 bundle":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 10 bundle");
-                        ApDebugLog.Instance.DisplayMessage("Got Anti-spark 10");
-                        FactSystem.AddToFact(new Fact("meta_progression_resource"), 10f);
-                        break;
-                    case "Anti-Spark 100 bundle":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 100 bundle");
-                        ApDebugLog.Instance.DisplayMessage("Got Anti-spark 100");
-                        FactSystem.AddToFact(new Fact("meta_progression_resource"), 100f);
-                        break;
-                    case "Anti-Spark 250 bundle":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 250 bundle");
-                        ApDebugLog.Instance.DisplayMessage("Got Anti-spark 250");
-                        FactSystem.AddToFact(new Fact("meta_progression_resource"), 250f);
-                        break;
-                    case "Anti-Spark 500 bundle":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 500 bundle");
-                        ApDebugLog.Instance.DisplayMessage("Got Anti-spark 500");
-                        FactSystem.AddToFact(new Fact("meta_progression_resource"), 500f);
-                        break;
-                    case "Anti-Spark 750 bundle":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 750 bundle");
-                        ApDebugLog.Instance.DisplayMessage("Got Anti-spark 750");
-                        FactSystem.AddToFact(new Fact("meta_progression_resource"), 750f);
-                        break;
-                    case "Anti-Spark 1k bundle":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 1000 bundle");
-                        ApDebugLog.Instance.DisplayMessage("Got Anti-spark 1000");
-                        FactSystem.AddToFact(new Fact("meta_progression_resource"), 1000f);
-                        break;
-                    case "Disaster Trap":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Disaster Trap");
-                        ApDebugLog.Instance.DisplayMessage("Got Disaster Trap");
-                        FactSystem.AddToFact(new Fact("APQueuedDisasterTraps"), 1f);
-                        worthMentioning = true;
-                        type = NotificationType.Trap;
-                        break;
-                    case "Landing Downgrade Trap":
-                        UnityMainThreadDispatcher.Instance().log("AP Got Landing Downgrade Trap");
-                        ApDebugLog.Instance.DisplayMessage("Got Landing Downgrade Trap");
-                        FactSystem.AddToFact(new Fact("APQueuedLandingTraps"), 1f);
-                        worthMentioning = true;
-                        type = NotificationType.Trap;
-                        break;
-                    default:
-                        UnityMainThreadDispatcher.Instance().logError("Item '" + itemName + "' has no handling");
-                        ApDebugLog.Instance.DisplayMessage($"<color=#FF0000>ERROR:</color> Item '{itemName}' has no handling.\nPlease screenshot this error and send it to the developer of this mod so it can be fixed.", isDebug:false, duration:20f);
-                        break;
+                    HandleItemUnlock(itemName);
+                    worthMentioning = true;
                 }
+                else {
+                    switch (itemName)
+                    {
+                        case "A New Future":
+                            // wincon item, ignore
+                            break;
+                        case "Progressive Shard":
+                            UnityMainThreadDispatcher.Instance().log("AP Got a Shard!");
+                            ApDebugLog.Instance.DisplayMessage("Got Shard");
+                            // Increase the number of shards that the player can use
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Progressive Shard");
+                            UpdateShardCount();
+                            DecideForceReload();
+                            break;
+                        case "Shard Shop Filler Item":
+                            // 80% sure this item can't actually spawn but I'll keep it here anyway
+                            UnityMainThreadDispatcher.Instance().log("AP Got a filler item");
+                            ApDebugLog.Instance.DisplayMessage("Got Filler");
+                            break;
+                        case "Wraith's Hourglass":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Ability Slomo");
+                            ApDebugLog.Instance.DisplayMessage("Got Wraith's Hourglass");
+                            HasteAP.SecretAbilityUnlock(AbilityKind.Slomo);
+                            SaveSystem.Save();
+                            worthMentioning = true;
+                            break;
+                        case "Heir's Javelin":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Ability Grapple");
+                            ApDebugLog.Instance.DisplayMessage("Got Heir's Javelin");
+                            HasteAP.SecretAbilityUnlock(AbilityKind.Grapple);
+                            SaveSystem.Save();
+                            worthMentioning = true;
+                            break;
+                        case "Sage's Cowl":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Ability Fly");
+                            ApDebugLog.Instance.DisplayMessage("Got Sage's Cowl");
+                            HasteAP.SecretAbilityUnlock(AbilityKind.Fly);
+                            SaveSystem.Save();
+                            worthMentioning = true;
+                            break;
+                        case "Courier's Board":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Ability Boost");
+                            ApDebugLog.Instance.DisplayMessage("Got Courier's Board");
+                            HasteAP.SecretAbilityUnlock(AbilityKind.BoardBoost);
+                            SaveSystem.Save();
+                            worthMentioning = true;
+                            break;
+                        case "Wraith":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Wraith");
+                            ApDebugLog.Instance.DisplayMessage("Got Wraith in hub");
+                            FactSystem.SetFact(new Fact("APWraithInHub"), 1f);
+                            worthMentioning = true;
+                            DecideForceReload();
+                            break;
+                        case "Niada":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Niada");
+                            ApDebugLog.Instance.DisplayMessage("Got Niada in hub");
+                            FactSystem.SetFact(new Fact("APHeirInHub"), 1f);
+                            worthMentioning = true;
+                            DecideForceReload();
+                            break;
+                        case "Daro":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Daro");
+                            ApDebugLog.Instance.DisplayMessage("Got Daro in hub");
+                            FactSystem.SetFact(new Fact("APSageInHub"), 1f);
+                            worthMentioning = true;
+                            DecideForceReload();
+                            break;
+                        case "The Captain":
+                            UnityMainThreadDispatcher.Instance().log("AP Got The Captain");
+                            ApDebugLog.Instance.DisplayMessage("Got The Captain");
+                            FactSystem.SetFact(new Fact("APCaptainInHub"), 1f);
+                            worthMentioning = true;
+                            DecideForceReload();
+                            break;
+                        case "Fashion Weeboh":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Fashion Weeboh");
+                            ApDebugLog.Instance.DisplayMessage("Got Fashion Weeboh");
+                            FactSystem.SetFact(new Fact("APFashionInHub"), 1f);
+                            worthMentioning = true;
+                            DecideForceReload();
+                            break;
+                        case "Progressive Speed Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Progressive Speed Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Progressive Speed Upgrade");
+                            FactSystem.AddToFact(new Fact("APSpeedUpgradesCollected"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Progressive Speed Upgrade");
+                            break;
+                        case "Max Health Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Max Health Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Max Health Upgrade");
+                            FactSystem.AddToFact(new Fact("APUpgradeMaxHealth"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Max Health Upgrade");
+                            Player.localPlayer.ResetStats();
+                            break;
+                        case "Max Lives Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Extra Lives Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Extra Lives Upgrade");
+                            // extra lives upgrade on first get because its coded really weirdly
+                            if (FactSystem.GetFact(new Fact("APUpgradeMaxLives")) == 0f) FactSystem.AddToFact(new Fact("APUpgradeMaxLives"), 1f);
+                            FactSystem.AddToFact(new Fact("APUpgradeMaxLives"), 1f);
+                            worthMentioning = true;
+                            Player.localPlayer.ResetStats();
+                            break;
+                        case "Max Energy Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Max Energy Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Max Energy Upgrade");
+                            FactSystem.AddToFact(new Fact("APUpgradeMaxEnergy"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Max Energy Upgrade");
+                            Player.localPlayer.ResetStats();
+                            break;
+                        case "Sparks in Fragments Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Sparks in Fragments Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Sparks in Fragments Upgrade");
+                            FactSystem.AddToFact(new Fact("APUpgradeLevelSparks"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Sparks in Fragments Upgrade");
+                            Player.localPlayer.ResetStats();
+                            break;
+                        case "Item Rarity Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Item Rarity Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Item Rarity Upgrade");
+                            FactSystem.AddToFact(new Fact("APUpgradeItemRarity"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Item Rarity Upgrade");
+                            Player.localPlayer.ResetStats();
+                            break;
+                        case "Starting Sparks Upgrade":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Starting Sparks Upgrade");
+                            ApDebugLog.Instance.DisplayMessage("Got Starting Sparks Upgrade");
+                            FactSystem.AddToFact(new Fact("APUpgradeStartingSparks"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Starting Sparks Upgrade");
+                            Player.localPlayer.ResetStats();
+                            break;
+                        case "Persistent Common Speed Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Common Speed Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Common Speed Item");
+                            FactSystem.AddToFact(new Fact("APCommonSpeedItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Common Speed Item");
+                            ForcePermItem(Rarity.Common, APItemCategory.Speed);
+                            break;
+                        case "Persistent Common Support Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Common Support Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Common Support Item");
+                            FactSystem.AddToFact(new Fact("APCommonSupportItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Common Support Item");
+                            ForcePermItem(Rarity.Common, APItemCategory.Support);
+                            break;
+                        case "Persistent Common Health Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Common Health Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Common Health Item");
+                            FactSystem.AddToFact(new Fact("APCommonHealthItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Common Health Item");
+                            ForcePermItem(Rarity.Common, APItemCategory.Health);
+                            break;
+                        case "Persistent Rare Speed Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Rare Speed Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Rare Speed Item");
+                            FactSystem.AddToFact(new Fact("APRareSpeedItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Rare Speed Item");
+                            ForcePermItem(Rarity.Rare, APItemCategory.Speed);
+                            break;
+                        case "Persistent Rare Support Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Rare Support Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Rare Support Item");
+                            FactSystem.AddToFact(new Fact("APRareSupportItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Rare Support Item");
+                            ForcePermItem(Rarity.Rare, APItemCategory.Support);
+                            break;
+                        case "Persistent Rare Health Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Rare Health Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Rare Health Item");
+                            FactSystem.AddToFact(new Fact("APRareHealthItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Rare Health Item");
+                            ForcePermItem(Rarity.Rare, APItemCategory.Health);
+                            break;
+                        case "Persistent Epic Speed Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Epic Speed Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Epic Speed Item");
+                            FactSystem.AddToFact(new Fact("APEpicSpeedItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Epic Speed Item");
+                            ForcePermItem(Rarity.Epic, APItemCategory.Speed);
+                            break;
+                        case "Persistent Epic Support Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Epic Support Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Epic Support Item");
+                            FactSystem.AddToFact(new Fact("APEpicSupportItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Epic Support Item");
+                            ForcePermItem(Rarity.Epic, APItemCategory.Support);
+                            break;
+                        case "Persistent Epic Health Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Epic Health Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Epic Health Item");
+                            FactSystem.AddToFact(new Fact("APEpicHealthItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Epic Health Item");
+                            ForcePermItem(Rarity.Epic, APItemCategory.Health);
+                            break;
+                        case "Persistent Legendary Item":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Persistent Legendary Item");
+                            ApDebugLog.Instance.DisplayMessage("Got Persistent Legendary Item");
+                            FactSystem.AddToFact(new Fact("APLegendaryItems"), 1f);
+                            worthMentioning = true;
+                            quantity = connection!.GetItemCount("Persistent Legendary Item");
+                            ForcePermItem(Rarity.Legendary, APItemCategory.Legendary);
+                            break;
+                        case "Anti-Spark 10 bundle":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 10 bundle");
+                            ApDebugLog.Instance.DisplayMessage("Got Anti-spark 10");
+                            FactSystem.AddToFact(new Fact("meta_progression_resource"), 10f);
+                            break;
+                        case "Anti-Spark 100 bundle":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 100 bundle");
+                            ApDebugLog.Instance.DisplayMessage("Got Anti-spark 100");
+                            FactSystem.AddToFact(new Fact("meta_progression_resource"), 100f);
+                            break;
+                        case "Anti-Spark 250 bundle":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 250 bundle");
+                            ApDebugLog.Instance.DisplayMessage("Got Anti-spark 250");
+                            FactSystem.AddToFact(new Fact("meta_progression_resource"), 250f);
+                            break;
+                        case "Anti-Spark 500 bundle":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 500 bundle");
+                            ApDebugLog.Instance.DisplayMessage("Got Anti-spark 500");
+                            FactSystem.AddToFact(new Fact("meta_progression_resource"), 500f);
+                            break;
+                        case "Anti-Spark 750 bundle":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 750 bundle");
+                            ApDebugLog.Instance.DisplayMessage("Got Anti-spark 750");
+                            FactSystem.AddToFact(new Fact("meta_progression_resource"), 750f);
+                            break;
+                        case "Anti-Spark 1k bundle":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Anti-Spark 1000 bundle");
+                            ApDebugLog.Instance.DisplayMessage("Got Anti-spark 1000");
+                            FactSystem.AddToFact(new Fact("meta_progression_resource"), 1000f);
+                            break;
+                        case "Disaster Trap":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Disaster Trap");
+                            ApDebugLog.Instance.DisplayMessage("Got Disaster Trap");
+                            FactSystem.AddToFact(new Fact("APQueuedDisasterTraps"), 1f);
+                            worthMentioning = true;
+                            type = NotificationType.Trap;
+                            break;
+                        case "Landing Downgrade Trap":
+                            UnityMainThreadDispatcher.Instance().log("AP Got Landing Downgrade Trap");
+                            ApDebugLog.Instance.DisplayMessage("Got Landing Downgrade Trap");
+                            FactSystem.AddToFact(new Fact("APQueuedLandingTraps"), 1f);
+                            worthMentioning = true;
+                            type = NotificationType.Trap;
+                            break;
+                        default:
+                            UnityMainThreadDispatcher.Instance().logError("Item '" + itemName + "' has no handling");
+                            ApDebugLog.Instance.DisplayMessage($"<color=#FF0000>ERROR:</color> Item '{itemName}' has no handling.\nPlease screenshot this error and send it to the developer of this mod so it can be fixed.", isDebug:false, duration:20f);
+                            break;
+                    }
+                }
+                
             }
             catch (Exception e)
             {
@@ -325,6 +435,32 @@ namespace Integration
             if (worthMentioning) Player.localPlayer.StartCoroutine(ItemPopup(itemName, givingPlayerName, quantity, type));
 
             //SaveSystem.Save();
+        }
+
+        private static void HandleItemUnlock(string itemName)
+        {
+            UnityMainThreadDispatcher.Instance().log($"AP Got ItemUnlock: {itemName}");
+            ApDebugLog.Instance.DisplayMessage($"Unlocked: {itemName}");
+            
+            // Create a fact name to track this unlock (e.g., "APItemUnlock_Adrenaline")
+            string unlockedItemFactName = $"APItemUnlock_{itemName}";
+            FactSystem.SetFact(new Fact(unlockedItemFactName), 1f);
+            
+            SaveSystem.Save();
+            
+            UnityMainThreadDispatcher.Instance().log($"AP Item {itemName} unlocked and saved. Fact value: {FactSystem.GetFact(new Fact(unlockedItemFactName))}");
+        }
+
+        public static bool IsItemUnlocked(string itemName)
+        {
+            string unlockedItemFactName = $"APItemUnlock_{itemName}";
+            float factValue = FactSystem.GetFact(new Fact(unlockedItemFactName));
+            return factValue > 0f;
+        }
+
+        public static bool IsItemLocked(string itemName)
+        {
+            return !IsItemUnlocked(itemName);
         }
 
         private static void DecideForceReload()
@@ -520,6 +656,126 @@ namespace Integration
                 SkinManager.Skin.DarkClown => "Twisted Flopsy",
                 SkinManager.Skin.Weeboh => "Weeboh",
                 SkinManager.Skin.Zoe64 => "Zoe 64",
+                _ => "NOT FOUND",
+            };
+        }
+
+        public static string GetItemName(string internalname)
+        {
+            return internalname switch
+            {
+                // =====================
+                // SPEED ITEMS
+                // =====================
+                "Active_TradeHpForBoost" => "Blood Engine",
+                "Active_PlaceRing" => "Boost Remote",
+                "BoostPerSpark" => "BOOSTR POG",
+                "OnBoostRing_ChanceOfRing" => "Bootleg Pattern",
+                "OnSparkCounter_Boost" => "Charge Boots",
+                "OnHeal_ChanceOfRing" => "Cherry on Top",
+                "Active_Grapple" => "Energy Lasso",
+                "AutoPilot" => "Experimental Autopilot",
+                "TakeDamageOnBadLandingButGetPermanentBoost" => "Experimental Thrusters",
+                "NEW_BoostIfLastLandingWasPerfect" => "Fragile Confidence",
+                "PermanentBoost" => "Golden Necklace",
+                "Stats_SparkInLevel" => "Big Spark Magnet",
+                "GetBoostWhenTakeDamage" => "Heir's Determination",
+                "Active_Jump" => "Mysterious Spring",
+                "BoostPerMissingHealth" => "Painful Coil",
+                "OnRunning_Ring" => "Pathfinder",
+                "GetBoostWithCooldown" => "Perpetual Motion Machine",
+                "NEW_Active_StickToGround" => "Personal Gravity Enhancer",
+                "NEW_Active_TempSpeed" => "Recyclable Rocket",
+                "NEW_PlaceRingInFront" => "Ring Materializer",
+                "OnCloseCall_ChanceOfRing" => "Risk and Reward",
+                "NEW_BigEffectOnSlowSpeed" => "Emergency Shoes",
+                "NEW_OnSparkPickupBigEffect" => "Greed Machine",
+                "Active_Boost" => "Rocket Boots",
+                "RandomChanceToBoostOnPerfectLanding" => "Secret Technique Instructions",
+                "GetBoostAtFullHealth" => "Shiny Anchor Pin",
+                "CloseCallBoost" => "Shortcut",
+                "Active_SparkDash" => "Spark Dasher",
+                "OnSparkPickup_ChanceOfRing" => "Spark Plug",
+                "OnGetCoin_Boost" => "Spark Powered Propeller",
+                "Active_Redirection" => "Standard Redirector",
+                "Active_Slomo" => "Time Dilation Thing",
+                "OnBoostRing_RingAndObstacle" => "Timeline Attractor",
+                "NEW_Active_Teleport" => "Timeline Shifter",
+                "NEW_StartWithBoost" => "Transition Slingshot",
+                "GetBoostOnHeal" => "Vitamins",
+                "BoostPerPerfectLandingStreak" => "Well Earned Confidence",
+                "TakeDamageOnCloseCallButGetPermanentBoost" => "Wingspan",
+
+                // =====================
+                // SUPPORT ITEMS
+                // =====================
+                "Stats_Luck" => "400-leaf Clover",
+                "CloseCallEnergy" => "Adrenaline",
+                "CooldownReductionOnPerfectLanding" => "Atomic Timepiece",
+                "Stats_CoinPickupRange" => "Big Spark Magnet",
+                "RandomChanceToSaveNonPerfectLanding" => "Clown Shoes",
+                "SparksOverTimeDamgeOnPickUp" => "Dangerous Investment Scheme",
+                "NEW_EnergyOnRunning" => "Dynamo Treadmill",
+                "CloseCallEcho" => "Flashback",
+                "CooldownReductionPerBoost" => "General Relativity",
+                "Stats_LuckOnFullHealth" => "Heart Shaped Mirror",
+                "SparksChanceOverTime" => "High Risk Investment",
+                "Stats_SparkOnTakeDamage" => "Instant Compensation Machine",
+                "SparksOverTime" => "Interest",
+                "SparksChanceOnPerfectLanding" => "Jackpot",
+                "LuckPerMissingHealth" => "Karma",
+                "SaveANonPerfectLandingWithCooldown" => "Momentum Recalibrator",
+                "CloseCallLuck" => "N-Dimensional-leaf Clover",
+                "RandomChanceToGetLuck" => "Overcomplicated Coin",
+                "CooldownReductionWithCooldown" => "Overwound Pocketwatch",
+                "CloseCallSave" => "Planar Reconfiguration",
+                "GetEnergyWithCooldown" => "Plutonium Coin",
+                "NEW_Active_KillObstacles" => "Portable Harvester",
+                "NEW_SparksOnRunning" => "Shimmering Condenser",
+                "OnGetCoin_Energy" => "Spark Furnace",
+                "SparksOnPerfectLanding" => "Steady Investment",
+                "CloseCallCooldown" => "Tight Schedule",
+                "NEW_Phoenix" => "Timeline Recalibrator",
+                "NEW_StartWithEnergy" => "Void Charger",
+                "NEW_StartWithMoney" => "Void Compressor",
+
+                // =====================
+                // HEALTH ITEMS
+                // =====================
+                "Regen" => "Aromatic Herbs",
+                "Stats_MaxHealthFlat" => "Big Pumpkin",
+                "Stats_MaxHealthMultiply" => "Big Squash",
+                "RegenPercent" => "Bitter Herbs",
+                "MaxHealthButDieOnOkOrBadLanding" => "Brittle Breastplate",
+                "CloseCallInv" => "Delayed Emergency Device",
+                "NEW_HealOnRunning" => "Distance-Based Health Insurance",
+                "OnBoostRing_ChanceOfInvulnerable" => "Energy Funnel",
+                "RegenPerMissingHealth" => "Extreme Herbs",
+                "NEW_RegenIfLastLandingWasPerfect" => "Fragile Taco",
+                "OnGetCoin_Invuln" => "Friendly Looking Star",
+                "BecomeInvulnerableForAMomentOnPerfectLanding" => "Grunt's Helmet",
+                "GetHealthWhenTakeDamage" => "Impact Activated Healing Drone",
+                "BlockDamageWithCooldown" => "Impulse Activated Stabilizer",
+                "NEW_InvuPerEnergyUsed" => "Intangibility",
+                "HealthRegenAtAlmostFullHealth" => "Leadership Pipe",
+                "RegenerationPerBoost" => "Low Grade Timeline Swapper",
+                "OnGetCoin_Heal" => "Mortar and Pestle",
+                "NEW_Active_KillObstaclesPulse" => "Otherworldly Contact",
+                "RandomChanceToRegen" => "Overclocked Medical Drone",
+                "GetHealedOnPerfectLanding" => "Performance Based Health Insurance",
+                "Active_Shield" => "Personal Matter Stabilizer",
+                "NEW_StartWithHeal" => "Pocket Snack",
+                "BlockDamageWithChance" => "Protective Medallion",
+                "ChanceForFullHP" => "Pungent Herbs",
+                "Stats_MaxHealthOnSpeed" => "Quick Taco",
+                "NEW_HealPerEnergyUsed" => "Reheated Soup",
+                "Active_Heal" => "Replenishing Vial",
+                "CloseCallHeal" => "Restorative Maneuver",
+                "NEW_RegenWithSpeed_Threshold" => "Velocity Powered Syringe",
+                "NEW_Active_HealWhenTakeDamage" => "Steel Hat Lining",
+                "NEW_RewindOnDamage" => "Timeline Refactor",
+                "Active_TradeSpeedForHeal" => "Blood Engine",
+
                 _ => "NOT FOUND",
             };
         }

--- a/Intergration.cs
+++ b/Intergration.cs
@@ -443,7 +443,8 @@ namespace Integration
             ApDebugLog.Instance.DisplayMessage($"Unlocked: {itemName}");
             
             // Create a fact name to track this unlock (e.g., "APItemUnlock_Adrenaline")
-            string unlockedItemFactName = $"APItemUnlock_{itemName}";
+            string safeItemName = itemName.Replace(" ", "").Replace("'", ""); // Remove spaces and apostrophes for fact naming
+            string unlockedItemFactName = $"APItemUnlock_{safeItemName}";
             FactSystem.SetFact(new Fact(unlockedItemFactName), 1f);
             
             SaveSystem.Save();
@@ -453,14 +454,20 @@ namespace Integration
 
         public static bool IsItemUnlocked(string itemName)
         {
-            string unlockedItemFactName = $"APItemUnlock_{itemName}";
+            string safeItemName = itemName.Replace(" ", "").Replace("'", "");
+            string unlockedItemFactName = $"APItemUnlock_{safeItemName}";
             float factValue = FactSystem.GetFact(new Fact(unlockedItemFactName));
             return factValue > 0f;
         }
 
-        public static bool IsItemLocked(string itemName)
+        public static int APItemUnlockCount()
         {
-            return !IsItemUnlocked(itemName);
+            int count = 0;
+            foreach (string item in ItemUnlocks)
+            {
+                if (IsItemUnlocked(item)) count++;
+            }
+            return count;
         }
 
         private static void DecideForceReload()


### PR DESCRIPTION
-Inspired by the implementation of Jokers in the Balatro AP
-Added a new option to the yaml "ItemUnlocks" which shuffles the items you'd buy mid run into the pool
-By default, if less than 3 items are unlocked, any missing shop slots are replaced with archipelago items
-I couldn't figure out how to do the void fragment items (the hard levels that give you an item upon completion) or endless mode, so this is just unlocking these items to appear in the shop
-I've also submitted a pr for the apworld as well